### PR TITLE
As of streamlink 5.0 the

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # docker-streamlink-recorder
+
 Automated Dockerfile to record livestreams with streamlink
 
 ## Description
+
 This is a Docker Container to record a livestream. It uses the official [Python Image](https://hub.docker.com/_/python) with the Tag *bullseye*  , installs [streamlink](https://github.com/streamlink/streamlink) and uses the Script [streamlink-recorder.sh](https://raw.githubusercontent.com/lauwarm/docker-streamlink-recorder/main/streamlink-recorder.sh) to periodically check if the stream is live.
 
 ## Usage
+
 To run the Container:
+
 ```bash
-$ docker run -v /path/to/vod/folder/:/home/download -e streamLink='' -e streamQuality='' -e streamName='' -e streamOptions='' -e uid='' -e gid='' lauwarm/streamlink-recorder
+docker run -v /path/to/vod/folder/:/home/download -e streamLink='' -e streamQuality='' -e streamName='' -e streamOptions='' -e uid='' -e gid='' lauwarm/streamlink-recorder
 ```
 
 Example:
+
 ```bash
-$ docker run -v /home/:/home/download -e streamLink='twitch.tv/twitch' -e streamQuality='best' -e streamName='twitch' -e streamOptions='--twitch-disable-hosting' -e uid='1001' -e gid='1001' lauwarm/streamlink-recorder
+docker run -v /home/:/home/download -e streamLink='twitch.tv/twitch' -e streamQuality='best' -e streamName='twitch' -e streamOptions='--twitch-disable-reruns' -e uid='1001' -e gid='1001' lauwarm/streamlink-recorder
 ```
 
 ## Notes
@@ -29,7 +34,7 @@ $ docker run -v /home/:/home/download -e streamLink='twitch.tv/twitch' -e stream
 
 `streamName` - name for the stream.
 
-`streamOptions` - streamlink flags (--twitch-disable-hosting, separated by space)
+`streamOptions` - streamlink flags (--twitch-disable-reruns, separated by space, see [Plugins](https://streamlink.github.io/plugins.html))
 
 `uid` - USER ID, map to your desired User ID (fallback to 9001)
 


### PR DESCRIPTION
"--twitch-disable-hosting" has been removed.
Added "--twitch-disable-reruns" as example.
Added link to streamlink plugins.
Fixes #51